### PR TITLE
fix for helper partial overwrites

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,21 @@ module.exports.register = function (Handlebars, options, params) {
     context = grunt.config.process(context);
 
     var template = Handlebars.partials[name];
-    var fn = Handlebars.compile(template);
+
+    // Check if this partial has already been compiled, whether via this helper, another helper or
+    // via the native {{>partial}} mechanism.  If so, reuse the compiled partial.
+    // see https://github.com/helpers/handlebars-helper-partial/issues/1
+    var fn;  
+    if (typeof template !== 'function') {
+
+        // not compiled, so we can compile it safely
+        fn = Handlebars.compile(template);
+    }
+    else {
+
+        // already compiled, just reuse it.
+        fn = template;
+    }
 
     var output = fn(context).replace(/^\s+/, '');
 

--- a/index.js
+++ b/index.js
@@ -60,14 +60,14 @@ module.exports.register = function (Handlebars, options, params) {
     // via the native {{>partial}} mechanism.  If so, reuse the compiled partial.
     // see https://github.com/helpers/handlebars-helper-partial/issues/1
     var fn;  
-    if (typeof template !== 'function') {
+    if (!_.isFunction(template)) {
 
         // not compiled, so we can compile it safely
         fn = Handlebars.compile(template);
     }
     else {
 
-        // already compiled, just reuse it.
+        // already compiled, just reuse it
         fn = template;
     }
 


### PR DESCRIPTION
fix for case when helper's partial overwrites already native's compiled {{>}} partial, or vice versa. see https://github.com/helpers/handlebars-helper-partial/issues/1
