### PR TITLE
omit page content front created context

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,12 +60,18 @@ module.exports.register = function (Handlebars, options, params) {
     };
 
     // now remove page content from this and opts before creating new context
-    context = _.extend({}, grunt.config.data, removePageContent(opts), removePageContent(this), opts.data[name], metadata, context);
+    context = _.extend({}, 
+                       grunt.config.data, 
+                       removePageContent(opts), 
+                       removePageContent(this), 
+                       opts.data[name], 
+                       metadata, 
+                       context);
 
     // process any templates inside context property values
     context = grunt.config.process(context);
 
-    // lookup this partial name from the partials registered with Handlebars
+    // look up this partial name from the partials registered with Handlebars
     var template = Handlebars.partials[name];
 
     // Check if this partial has already been compiled, whether via this helper, another helper or


### PR DESCRIPTION
remove page content properties (`pages` and `pagination`) from `this` and `opts` contexts before creating final context.  this is done to prevent LoDash templates in content being unintentionally evaluated and failing due to missing properties. see https://github.com/helpers/handlebars-helper-partial/issues/3

currently there is no test for this condition since i am not sure how the tests work yet ;)

note that this fix should eventually end up in https://github.com/helpers/handlebars-helper-include as well or better yet they should share code base or lib.
